### PR TITLE
[YM-19958] Replacing % symbol

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,14 +1,9 @@
 # Translate - Sketch plugin
 A sketch plugin to translate copy content into iOS and Android ready locale file.
 
-To compile the tool
-1. cd sketch-translate-mac
-2. carthage bootstrap --platform mac --use-ssh
-3. compile via Xcode
-
-To run the Script:
-1. Get the identifier of the Google Sheet that contains the copy
-2. Type "main.rb <identifier>"
+To run the script:
+1. Get the identifier of the Google Document that contains the copy
+2. `ruby main.rb <identifier>`
 
 ## How it works
 * **Step 1** Manage copy in a Google Sheet

--- a/main.rb
+++ b/main.rb
@@ -68,6 +68,7 @@ def transformValueToAndroid(value)
   value = value.gsub("“", "\\\"")
   value = value.gsub("&", "&amp;")
   value = value.gsub("…", "&#8230;")
+  value = value.gsub("%", "\%%")
 
   value.gsub!(/\{.[^\}]*-([0-9]+)\}/) { |not_needed| val = "%#{$1}$s" }
 

--- a/main.rb
+++ b/main.rb
@@ -50,6 +50,7 @@ def transformValueToIOS(value)
   value = value.gsub("\n", "\\n")
   value = value.gsub("\"", "\\\"")
   value = value.gsub("\'", "\\\\'")
+  value = value.gsub("%", "\%%")
 
   value.gsub!(/\{.[^\}]*-([0-9]+)\}/) { |not_needed| val = "%#{$1}$@" }
 


### PR DESCRIPTION
The % symbol needs to be escaped as it doesn't work in the localisation files for both Android and iOS.