### PR TITLE
[Task] YM-30128: Adds ability for SmartID to have translations

### DIFF
--- a/ci/scripts/update-localisation.sh
+++ b/ci/scripts/update-localisation.sh
@@ -45,6 +45,6 @@ git add $YOTI_IOS_FILE_NAME
 git diff-index --quiet HEAD $YOTI_IOS_FILE_NAME || git commit -m "Update Yoti strings from spreadsheet merge"
 
 for TARGET in "${TARGETS[@]}"; do
-    git add strings_${TARGET}.xml
-    git diff-index --quiet HEAD strings_${TARGET}.xml || git commit -m "Update "${TARGET}" strings from spreadsheet merge"
+    git add ios_${TARGET}.strings
+    git diff-index --quiet HEAD ios_${TARGET}.strings || git commit -m "Update "${TARGET}" strings from spreadsheet merge"
 done

--- a/ci/scripts/update-localisation.sh
+++ b/ci/scripts/update-localisation.sh
@@ -8,31 +8,32 @@
 # ios-repo contains checked out strings-merger repo. New iOS strings will be committed here.
 
 #Android paths
-YOTI_ANDROID_IN_PATH=strings.xml
-POSTOFFICE_ANDROID_IN_PATH=strings_postofficeid.xml
-
-YOTI_ANDROID_OUT_PATH=en/Android/strings.xml
-POSTOFFICE_ANDROID_OUT_PATH=en/Android/strings_postofficeid.xml
-
-#iOS file names
+YOTI_ANDROID_FILE_NAME=strings.xml
 YOTI_IOS_FILE_NAME=ios.strings
-POSTOFFICE_IOS_FILE_NAME=ios_postofficeid.strings
 
-cp results/$YOTI_ANDROID_IN_PATH android-repo/$YOTI_ANDROID_OUT_PATH
-cp results/$POSTOFFICE_ANDROID_IN_PATH android-repo/$POSTOFFICE_ANDROID_OUT_PATH
+#Additional white label targets
+TARGETS=("postofficeid" "smartid")
+
+cp results/$YOTI_ANDROID_FILE_NAME android-repo/$YOTI_ANDROID_FILE_NAME
 cp results/$YOTI_IOS_FILE_NAME ios-repo/$YOTI_IOS_FILE_NAME
-cp results/$POSTOFFICE_IOS_FILE_NAME ios-repo/$POSTOFFICE_IOS_FILE_NAME
+
+for TARGET in "${TARGETS[@]}"; do
+    cp results/strings_${TARGET}.xml android-repo/en/Android/strings_${TARGET}.xml
+    cp results/ios_${TARGET}.strings ios-repo/ios_${TARGET}.strings
+done
 
 ## Android
 cd android-repo
 git config user.email "ci@yoti.com"
 git config user.name "yoti-ci"
 
-git add $YOTI_ANDROID_OUT_PATH
-git diff-index --quiet HEAD $YOTI_ANDROID_OUT_PATH || git commit -m "Update Yoti strings from spreadsheet merge"
+git add en/Android/$YOTI_ANDROID_FILE_NAME
+git diff-index --quiet HEAD en/Android/$YOTI_ANDROID_FILE_NAME || git commit -m "Update Yoti strings from spreadsheet merge"
 
-git add $POSTOFFICE_ANDROID_OUT_PATH
-git diff-index --quiet HEAD $POSTOFFICE_ANDROID_OUT_PATH || git commit -m "Update PostOffice strings from spreadsheet merge"
+for TARGET in "${TARGETS[@]}"; do
+    git add en/Android/strings_${target}.xml
+    git diff-index --quiet HEAD en/Android/strings_${TARGET}.xml || git commit -m "Update "${TARGET}" strings from spreadsheet merge"
+done
 
 ## iOS
 cd ../ios-repo
@@ -42,5 +43,7 @@ git config user.name "yoti-ci"
 git add $YOTI_IOS_FILE_NAME
 git diff-index --quiet HEAD $YOTI_IOS_FILE_NAME || git commit -m "Update Yoti strings from spreadsheet merge"
 
-git add $POSTOFFICE_IOS_FILE_NAME
-git diff-index --quiet HEAD $POSTOFFICE_IOS_FILE_NAME || git commit -m "Update PostOffice strings from spreadsheet merge"
+for TARGET in "${TARGETS[@]}"; do
+    git add strings_${target}.xml
+    git diff-index --quiet HEAD strings_${target}.xml || git commit -m "Update "${target}" strings from spreadsheet merge"
+done

--- a/ci/scripts/update-localisation.sh
+++ b/ci/scripts/update-localisation.sh
@@ -10,15 +10,16 @@
 #Android paths
 YOTI_ANDROID_FILE_NAME=strings.xml
 YOTI_IOS_FILE_NAME=ios.strings
+ANDROID_BASE_PATH=en/Android/
 
 #Additional white label targets
 TARGETS=("postofficeid" "smartid")
 
-cp results/$YOTI_ANDROID_FILE_NAME android-repo/$YOTI_ANDROID_FILE_NAME
+cp results/$YOTI_ANDROID_FILE_NAME android-repo/${ANDROID_BASE_PATH}${YOTI_ANDROID_FILE_NAME}
 cp results/$YOTI_IOS_FILE_NAME ios-repo/$YOTI_IOS_FILE_NAME
 
 for TARGET in "${TARGETS[@]}"; do
-    cp results/strings_${TARGET}.xml android-repo/en/Android/strings_${TARGET}.xml
+    cp results/strings_${TARGET}.xml android-repo/${ANDROID_BASE_PATH}strings_${TARGET}.xml
     cp results/ios_${TARGET}.strings ios-repo/ios_${TARGET}.strings
 done
 
@@ -27,12 +28,12 @@ cd android-repo
 git config user.email "ci@yoti.com"
 git config user.name "yoti-ci"
 
-git add en/Android/$YOTI_ANDROID_FILE_NAME
-git diff-index --quiet HEAD en/Android/$YOTI_ANDROID_FILE_NAME || git commit -m "Update Yoti strings from spreadsheet merge"
+git add ${ANDROID_BASE_PATH}${YOTI_ANDROID_FILE_NAME}
+git diff-index --quiet HEAD ${ANDROID_BASE_PATH}${YOTI_ANDROID_FILE_NAME} || git commit -m "Update Yoti strings from spreadsheet merge"
 
 for TARGET in "${TARGETS[@]}"; do
     git add en/Android/strings_${target}.xml
-    git diff-index --quiet HEAD en/Android/strings_${TARGET}.xml || git commit -m "Update "${TARGET}" strings from spreadsheet merge"
+    git diff-index --quiet HEAD ${ANDROID_BASE_PATH}strings_${TARGET}.xml || git commit -m "Update "${TARGET}" strings from spreadsheet merge"
 done
 
 ## iOS
@@ -44,6 +45,6 @@ git add $YOTI_IOS_FILE_NAME
 git diff-index --quiet HEAD $YOTI_IOS_FILE_NAME || git commit -m "Update Yoti strings from spreadsheet merge"
 
 for TARGET in "${TARGETS[@]}"; do
-    git add strings_${target}.xml
-    git diff-index --quiet HEAD strings_${target}.xml || git commit -m "Update "${target}" strings from spreadsheet merge"
+    git add strings_${TARGET}.xml
+    git diff-index --quiet HEAD strings_${TARGET}.xml || git commit -m "Update "${TARGET}" strings from spreadsheet merge"
 done

--- a/ci/tasks/generate-strings.yml
+++ b/ci/tasks/generate-strings.yml
@@ -20,7 +20,6 @@ run:
 
 platform: linux
 image_resource:
-  type: docker-image
+  type: registry-image
   source:
-    repository: dr.internal.yoti.com:443/android/task-ruby-alpine
- 
+    repository: registry.infra.yoti.com/android/task-ruby-alpine

--- a/ci/tasks/update-localisation.yml
+++ b/ci/tasks/update-localisation.yml
@@ -22,7 +22,6 @@ run:
 
 platform: linux
 image_resource:
-  type: docker-image
+  type: registry-image
   source:
-    repository: dr.internal.yoti.com:443/android/task-ruby-alpine
- 
+    repository: registry.infra.yoti.com/android/task-ruby-alpine

--- a/main.rb
+++ b/main.rb
@@ -48,11 +48,13 @@ def createLocalisationMap(worksheet)
     end
   end
 
+  puts "White label indexes: #{whiteLabelIndicies}"
+
   # Create the map [key:value]
   (2..worksheet.num_rows).each do |row|
     key = worksheet[row, localizationKeyIndex]
     yotiValue = worksheet[row, yotiValueIndex]
-    whiteLabelValues = Hash.new
+    whiteLabelValues = []
     whiteLabelIndicies.each {|whiteLabelIndex| whiteLabelValues.push(worksheet[row, whiteLabelIndex]) }
 
     # Yoti copy
@@ -173,6 +175,9 @@ session = GoogleDrive::Session.from_config(drive_config_path)
 spreadsheet = session.spreadsheet_by_key(spreadsheetKey)
 spreadsheet.worksheets.each do |worksheet|
   if (worksheet.title == "iOS Export")
+
+    puts "Checking iOS Export"
+
     resultsMaps = createLocalisationMap(worksheet)
     generateIOSFile("results/ios.strings", resultsMaps[0])
 
@@ -182,6 +187,9 @@ spreadsheet.worksheets.each do |worksheet|
       end
     end
   elsif (worksheet.title == "Android Export")
+
+    puts "Checking Android Export"
+
     resultsMaps = createLocalisationMap(worksheet)
     generateAndroidFile("results/strings.xml", resultsMaps[0])
     resultsMaps.each_with_index do |resultsMap, index|

--- a/main.rb
+++ b/main.rb
@@ -18,7 +18,7 @@ if (drive_config_path == nil)
   drive_config_path = "config.json"
 end
 
-$whiteLabels=["postofficeid" "smartid"]
+$whiteLabels=["postofficeid", "smartid"]
 
 def createLocalisationMap(worksheet)
   whiteLabelsColumnName=["PO Value" "SmartID Value"]

--- a/main.rb
+++ b/main.rb
@@ -70,9 +70,9 @@ def createLocalisationMap(worksheet)
       if (!key.empty? && !whiteLabelValue.empty?)
         whiteLabelKey = key + "#" + $whiteLabels[index] + "#"
         if whiteLabelValue == "$NO_VALUE"
-          whiteLabelResult[whiteLabelKey] = ""
+          whiteLabelResult[index][whiteLabelKey] = ""
         else
-          whiteLabelResult[whiteLabelKey] = whiteLabelValue
+          whiteLabelResult[index][whiteLabelKey] = whiteLabelValue
         end
       end
     end

--- a/main.rb
+++ b/main.rb
@@ -76,6 +76,8 @@ def createLocalisationMap(worksheet)
   results = [yotiResult]
   whiteLabelResult.each{|result| results.push(result) }
 
+  puts "Apps: #{results.count}"
+
   return results
 end
 

--- a/main.rb
+++ b/main.rb
@@ -18,18 +18,20 @@ if (drive_config_path == nil)
   drive_config_path = "config.json"
 end
 
-whiteLabels=["postofficeid" "smartid"]
-whiteLabelsColumnName=["PO Value" "SmartID Value"]
+$whiteLabels=["postofficeid" "smartid"]
 
 def createLocalisationMap(worksheet)
+  whiteLabelsColumnName=["PO Value" "SmartID Value"]
+
+
   yotiResult = Hash.new
   whiteLabelResult = []
-  whiteLabels.each {|whiteLabel| whiteLabelResult.push(Hash.new) }
+  $whiteLabels.each {|whiteLabel| whiteLabelResult.push(Hash.new) }
 
   localizationKeyIndex = 0
   yotiValueIndex = 0
   whiteLabelIndicies = []
-  whiteLabels.each {|whiteLabel| whiteLabelIndicies.push(0) }
+  $whiteLabels.each {|whiteLabel| whiteLabelIndicies.push(0) }
 
   # Find the Key and Value column indexes
   (1..worksheet.num_cols).each do |col|
@@ -39,7 +41,7 @@ def createLocalisationMap(worksheet)
     if worksheet[1, col] == "Localisation Value"
       yotiValueIndex = col
     end
-    whiteLabels.each_with_index do |whiteLabel, index|
+    $whiteLabels.each_with_index do |whiteLabel, index|
       if worksheet[1, col] == whiteLabelsColumnName[index]
         whiteLabelIndicies[index] = col
       end
@@ -61,7 +63,7 @@ def createLocalisationMap(worksheet)
     # White label copy
     whiteLabelValues.each_with_index do |whiteLabelValue, index|
       if (!key.empty? && !whiteLabelValue.empty?)
-        whiteLabelKey = key + "#" + whiteLabels[index] + "#"
+        whiteLabelKey = key + "#" + $whiteLabels[index] + "#"
         if whiteLabelValue == "$NO_VALUE"
           whiteLabelResult[whiteLabelKey] = ""
         else
@@ -176,7 +178,7 @@ spreadsheet.worksheets.each do |worksheet|
 
     resultsMaps.each_with_index do |resultsMap, index|
       if index != 0
-        generateIOSFile("results/ios_" + whiteLabels[index] + ".strings", resultsMap)
+        generateIOSFile("results/ios_" + $whiteLabels[index] + ".strings", resultsMap)
       end
     end
   elsif (worksheet.title == "Android Export")
@@ -184,7 +186,7 @@ spreadsheet.worksheets.each do |worksheet|
     generateAndroidFile("results/strings.xml", resultsMaps[0])
     resultsMaps.each_with_index do |resultsMap, index|
       if index != 0
-        generateIOSFile("results/results/strings_" + whiteLabels[index] + ".xml", resultsMap)
+        generateIOSFile("results/results/strings_" + $whiteLabels[index] + ".xml", resultsMap)
       end
     end
   end

--- a/main.rb
+++ b/main.rb
@@ -42,16 +42,11 @@ def createLocalisationMap(worksheet)
       yotiValueIndex = col
     end
     $whiteLabels.each_with_index do |whiteLabel, index|
-      puts "Checking white labels columns #{whiteLabel}"
       if worksheet[1, col] == whiteLabelsColumnName[index]
         whiteLabelIndicies[index] = col
-        puts "Found at #{col}"
       end
     end
   end
-
-  puts "Whitelabels: #{$whiteLabels}"
-  puts "White label indexes: #{whiteLabelIndicies}"
 
   # Create the map [key:value]
   (2..worksheet.num_rows).each do |row|
@@ -184,9 +179,12 @@ spreadsheet.worksheets.each do |worksheet|
     resultsMaps = createLocalisationMap(worksheet)
     generateIOSFile("results/ios.strings", resultsMaps[0])
 
+    puts "iOS Yoti written"
+
     resultsMaps.each_with_index do |resultsMap, index|
       if index != 0
         generateIOSFile("results/ios_" + $whiteLabels[index] + ".strings", resultsMap)
+        puts "iOS #{$whiteLabels[index]} written"
       end
     end
   elsif (worksheet.title == "Android Export")
@@ -195,9 +193,13 @@ spreadsheet.worksheets.each do |worksheet|
 
     resultsMaps = createLocalisationMap(worksheet)
     generateAndroidFile("results/strings.xml", resultsMaps[0])
+
+    puts "Android Yoti written"
+
     resultsMaps.each_with_index do |resultsMap, index|
       if index != 0
         generateAndroidFile("results/strings_" + $whiteLabels[index] + ".xml", resultsMap)
+        puts "Android #{$whiteLabels[index]} written"
       end
     end
   end

--- a/main.rb
+++ b/main.rb
@@ -18,13 +18,18 @@ if (drive_config_path == nil)
   drive_config_path = "config.json"
 end
 
+whiteLabels=["postofficeid" "smartid"]
+whiteLabelsColumnName=["PO Value" "SmartID Value"]
+
 def createLocalisationMap(worksheet)
   yotiResult = Hash.new
-  postOfficeResult = Hash.new
+  whiteLabelResult = []
+  whiteLabels.each {|whiteLabel| whiteLabelResult.push(Hash.new) }
 
   localizationKeyIndex = 0
   yotiValueIndex = 0
-  postOfficeValueIndex = 0
+  whiteLabelIndicies = []
+  whiteLabels.each {|whiteLabel| whiteLabelIndicies.push(0) }
 
   # Find the Key and Value column indexes
   (1..worksheet.num_cols).each do |col|
@@ -34,8 +39,10 @@ def createLocalisationMap(worksheet)
     if worksheet[1, col] == "Localisation Value"
       yotiValueIndex = col
     end
-    if worksheet[1, col] == "PO Value"
-      postOfficeValueIndex = col
+    whiteLabels.each_with_index do |whiteLabel, index|
+      if worksheet[1, col] == whiteLabelsColumnName[index]
+        whiteLabelIndicies[index] = col
+      end
     end
   end
 
@@ -43,25 +50,31 @@ def createLocalisationMap(worksheet)
   (2..worksheet.num_rows).each do |row|
     key = worksheet[row, localizationKeyIndex]
     yotiValue = worksheet[row, yotiValueIndex]
-    postOfficeValue = worksheet[row, postOfficeValueIndex]
+    whiteLabelValues = Hash.new
+    whiteLabelIndicies.each {|whiteLabelIndex| whiteLabelValues.push(worksheet[row, whiteLabelIndex]) }
 
     # Yoti copy
     if (!key.empty?)
       yotiResult[key] = yotiValue
     end
-
-    # PostOffice copy
-    if (!key.empty? && !postOfficeValue.empty?)
-      postOfficeKey = key + "#postofficeid#"
-      if postOfficeValue == "$NO_VALUE"
-          postOfficeResult[postOfficeKey] = ""
-      else
-          postOfficeResult[postOfficeKey] = postOfficeValue
+    
+    # White label copy
+    whiteLabelValues.each_with_index do |whiteLabelValue, index|
+      if (!key.empty? && !whiteLabelValue.empty?)
+        whiteLabelKey = key + "#" + whiteLabels[index] + "#"
+        if whiteLabelValue == "$NO_VALUE"
+          whiteLabelResult[whiteLabelKey] = ""
+        else
+          whiteLabelResult[whiteLabelKey] = whiteLabelValue
+        end
       end
-    end
+    end     
   end
 
-  return yotiResult, postOfficeResult
+  results = [yotiResult]
+  whiteLabelResult.each{|result| results.push(result) }
+
+  return results
 end
 
 def transformValueToIOS(value)
@@ -158,12 +171,21 @@ session = GoogleDrive::Session.from_config(drive_config_path)
 spreadsheet = session.spreadsheet_by_key(spreadsheetKey)
 spreadsheet.worksheets.each do |worksheet|
   if (worksheet.title == "iOS Export")
-    yotiResultMap, postOfficeResultMap = createLocalisationMap(worksheet)
-    generateIOSFile("results/ios.strings", yotiResultMap)
-    generateIOSFile("results/ios_postofficeid.strings", postOfficeResultMap)
+    resultsMaps = createLocalisationMap(worksheet)
+    generateIOSFile("results/ios.strings", resultsMaps[0])
+
+    resultsMaps.each_with_index do |resultsMap, index|
+      if index != 0
+        generateIOSFile("results/ios_" + whiteLabels[index] + ".strings", resultsMap)
+      end
+    end
   elsif (worksheet.title == "Android Export")
-    yotiResultMap, postOfficeResultMap = createLocalisationMap(worksheet)
-    generateAndroidFile("results/strings.xml", yotiResultMap)
-    generateAndroidFile("results/strings_postofficeid.xml", postOfficeResultMap)
+    resultsMaps = createLocalisationMap(worksheet)
+    generateAndroidFile("results/strings.xml", resultsMaps[0])
+    resultsMaps.each_with_index do |resultsMap, index|
+      if index != 0
+        generateIOSFile("results/results/strings_" + whiteLabels[index] + ".xml", resultsMap)
+      end
+    end
   end
 end

--- a/main.rb
+++ b/main.rb
@@ -197,7 +197,7 @@ spreadsheet.worksheets.each do |worksheet|
     generateAndroidFile("results/strings.xml", resultsMaps[0])
     resultsMaps.each_with_index do |resultsMap, index|
       if index != 0
-        generateIOSFile("results/results/strings_" + $whiteLabels[index] + ".xml", resultsMap)
+        generateAndroidFile("results/strings_" + $whiteLabels[index] + ".xml", resultsMap)
       end
     end
   end

--- a/main.rb
+++ b/main.rb
@@ -185,8 +185,8 @@ spreadsheet.worksheets.each do |worksheet|
 
     resultsMaps.each_with_index do |resultsMap, index|
       if index != 0
-        generateIOSFile("results/ios_" + $whiteLabels[index] + ".strings", resultsMap)
-        puts "iOS #{$whiteLabels[index]} written"
+        generateIOSFile("results/ios_" + $whiteLabels[index - 1] + ".strings", resultsMap)
+        puts "iOS #{$whiteLabels[index - 1]} written"
       end
     end
   elsif (worksheet.title == "Android Export")
@@ -200,8 +200,8 @@ spreadsheet.worksheets.each do |worksheet|
 
     resultsMaps.each_with_index do |resultsMap, index|
       if index != 0
-        generateAndroidFile("results/strings_" + $whiteLabels[index] + ".xml", resultsMap)
-        puts "Android #{$whiteLabels[index]} written"
+        generateAndroidFile("results/strings_" + $whiteLabels[index - 1] + ".xml", resultsMap)
+        puts "Android #{$whiteLabels[index - 1]} written"
       end
     end
   end

--- a/main.rb
+++ b/main.rb
@@ -21,7 +21,7 @@ end
 $whiteLabels=["postofficeid", "smartid"]
 
 def createLocalisationMap(worksheet)
-  whiteLabelsColumnName=["PO Value" "SmartID Value"]
+  whiteLabelsColumnName=["PO Value", "SmartID Value"]
 
 
   yotiResult = Hash.new

--- a/main.rb
+++ b/main.rb
@@ -75,9 +75,6 @@ def createLocalisationMap(worksheet)
 
   results = [yotiResult]
   whiteLabelResult.each{|result| results.push(result) }
-
-  puts "Apps: #{results.count}"
-
   return results
 end
 

--- a/main.rb
+++ b/main.rb
@@ -68,7 +68,7 @@ def createLocalisationMap(worksheet)
           whiteLabelResult[whiteLabelKey] = whiteLabelValue
         end
       end
-    end     
+    end
   end
 
   results = [yotiResult]

--- a/main.rb
+++ b/main.rb
@@ -42,8 +42,10 @@ def createLocalisationMap(worksheet)
       yotiValueIndex = col
     end
     $whiteLabels.each_with_index do |whiteLabel, index|
+      puts "Checking white labels columns #{whiteLabel}"
       if worksheet[1, col] == whiteLabelsColumnName[index]
         whiteLabelIndicies[index] = col
+        puts "Found at #{col}"
       end
     end
   end

--- a/main.rb
+++ b/main.rb
@@ -48,6 +48,7 @@ def createLocalisationMap(worksheet)
     end
   end
 
+  puts "Whitelabels: #{$whiteLabels}"
   puts "White label indexes: #{whiteLabelIndicies}"
 
   # Create the map [key:value]


### PR DESCRIPTION
## Purpose
Adds ability for SmartID to have translations

## External References (e.g. Jira / Zeplin / Confluence)
[Jira](https://lampkicking.atlassian.net/browse/YM-30128)

## Approach
Repeat PO processes

## Scope of changes
_Is there any area that might be affected?_

## Checklist
[ ] - See that the tool continues to run: https://concourse.internal.yoti.com/teams/mobile/pipelines/mobile-tools/jobs/generate_master_copy/builds/35

#### Tagged

