### PR TITLE
[YM-33026]Add support for master string files

### DIFF
--- a/ci/scripts/update-localisation.sh
+++ b/ci/scripts/update-localisation.sh
@@ -14,7 +14,7 @@ if [ -z "${IS_RELEASE##*true*}" ]; then
   ANDROID_BASE_PATH=en/Android/
 else
   YOTI_ANDROID_FILE_NAME=master_strings.xml
-  YOTI_IOS_FILE_NAME=ios.master.strings
+  YOTI_IOS_FILE_NAME=ios_master.strings
   ANDROID_BASE_PATH=en/Android/
 fi
 

--- a/ci/scripts/update-localisation.sh
+++ b/ci/scripts/update-localisation.sh
@@ -8,9 +8,15 @@
 # ios-repo contains checked out strings-merger repo. New iOS strings will be committed here.
 
 #Android paths
-YOTI_ANDROID_FILE_NAME=strings.xml
-YOTI_IOS_FILE_NAME=ios.strings
-ANDROID_BASE_PATH=en/Android/
+if [ -z "${IS_RELEASE##*true*}" ]; then
+  YOTI_ANDROID_FILE_NAME=strings.xml
+  YOTI_IOS_FILE_NAME=ios.strings
+  ANDROID_BASE_PATH=en/Android/
+else [ -z "${IS_RELEASE##*false*}" ];
+  YOTI_ANDROID_FILE_NAME=master_strings.xml
+  YOTI_IOS_FILE_NAME=ios.master.strings
+  ANDROID_BASE_PATH=en/Android/
+fi
 
 #Additional white label targets
 TARGETS=("postofficeid" "smartid")

--- a/ci/scripts/update-localisation.sh
+++ b/ci/scripts/update-localisation.sh
@@ -12,7 +12,7 @@ if [ -z "${IS_RELEASE##*true*}" ]; then
   YOTI_ANDROID_FILE_NAME=strings.xml
   YOTI_IOS_FILE_NAME=ios.strings
   ANDROID_BASE_PATH=en/Android/
-else [ -z "${IS_RELEASE##*false*}" ];
+else
   YOTI_ANDROID_FILE_NAME=master_strings.xml
   YOTI_IOS_FILE_NAME=ios.master.strings
   ANDROID_BASE_PATH=en/Android/

--- a/ci/tasks/generate-strings.yml
+++ b/ci/tasks/generate-strings.yml
@@ -13,10 +13,11 @@ outputs:
 params:
   # Config file path to authenticate on drive
   DRIVE_CONFIG: drive-config/content
+  isRelease: true
 
 run:
   path: ruby
-  args: [ scripts/main.rb, ((spreadsheet-id))]
+  args: [ scripts/main.rb, ((spreadsheet-id)), ((isRelease))]
 
 platform: linux
 image_resource:

--- a/ci/tasks/update-localisation.yml
+++ b/ci/tasks/update-localisation.yml
@@ -15,7 +15,8 @@ outputs:
   - name: android-repo
   - name: ios-repo
 
-params: {}
+params:
+  IS_RELEASE: true
 
 run:
   path: scripts/ci/scripts/update-localisation.sh

--- a/main.rb
+++ b/main.rb
@@ -212,7 +212,7 @@ spreadsheet.worksheets.each do |worksheet|
     resultsMaps.each_with_index do |resultsMap, index|
       if index != 0
         if isRelease == true
-            generateAndroidFile("results/master_strings_" + $whiteLabels[index - 1] + ".xml", resultsMap)
+            generateAndroidFile("results/strings_" + $whiteLabels[index - 1] + ".xml", resultsMap)
             puts "Android #{$whiteLabels[index - 1]} written"
         else
             generateAndroidFile("results/master_strings_" + $whiteLabels[index - 1] + ".xml", resultsMap)

--- a/main.rb
+++ b/main.rb
@@ -162,7 +162,7 @@ end
 
 spreadsheetKey = ARGV[0]
 isRelease = ARGV[1]
-if spreadsheetKey || isRelease == nil
+if spreadsheetKey == nil
   puts "Script called with wrong number of parameters"
   exit 1
 end
@@ -177,7 +177,7 @@ spreadsheet.worksheets.each do |worksheet|
     puts "Checking iOS Export"
 
     resultsMaps = createLocalisationMap(worksheet)
-    if isRelease = true
+    if isRelease == true
         generateIOSFile("results/ios.strings", resultsMaps[0])
     elsif
         generateIOSFile("results/ios.master.strings", resultsMaps[0])
@@ -187,7 +187,7 @@ spreadsheet.worksheets.each do |worksheet|
 
     resultsMaps.each_with_index do |resultsMap, index|
     if index != 0
-      if isRelease = true
+      if isRelease == true
           generateIOSFile("results/ios_" + $whiteLabels[index - 1] + ".strings", resultsMap)
           puts "iOS #{$whiteLabels[index - 1]} written"
       elsif
@@ -200,7 +200,7 @@ spreadsheet.worksheets.each do |worksheet|
     puts "Checking Android Export"
 
     resultsMaps = createLocalisationMap(worksheet)
-    if isRelease = true
+    if isRelease == true
         generateAndroidFile("results/strings.xml", resultsMaps[0])
     elsif
         generateAndroidFile("results/master_strings.xml", resultsMaps[0])
@@ -210,7 +210,7 @@ spreadsheet.worksheets.each do |worksheet|
 
     resultsMaps.each_with_index do |resultsMap, index|
       if index != 0
-        if isRelease = true
+        if isRelease == true
             generateAndroidFile("results/master_strings_" + $whiteLabels[index - 1] + ".xml", resultsMap)
             puts "Android #{$whiteLabels[index - 1]} written"
         elsif

--- a/main.rb
+++ b/main.rb
@@ -177,7 +177,7 @@ spreadsheet.worksheets.each do |worksheet|
     puts "Checking iOS Export"
 
     resultsMaps = createLocalisationMap(worksheet)
-    if isRelease == true
+    if isRelease == "true"
         generateIOSFile("results/ios.strings", resultsMaps[0])
     else
         generateIOSFile("results/ios.master.strings", resultsMaps[0])
@@ -187,7 +187,7 @@ spreadsheet.worksheets.each do |worksheet|
 
     resultsMaps.each_with_index do |resultsMap, index|
       if index != 0
-        if isRelease == true
+        if isRelease == "true"
             generateIOSFile("results/ios_" + $whiteLabels[index - 1] + ".strings", resultsMap)
             puts "iOS #{$whiteLabels[index - 1]} written"
         else
@@ -201,7 +201,7 @@ spreadsheet.worksheets.each do |worksheet|
     puts "Checking Android Export"
 
     resultsMaps = createLocalisationMap(worksheet)
-    if isRelease == true
+    if isRelease == "true"
         generateAndroidFile("results/strings.xml", resultsMaps[0])
     else
         generateAndroidFile("results/master_strings.xml", resultsMaps[0])
@@ -211,7 +211,7 @@ spreadsheet.worksheets.each do |worksheet|
 
     resultsMaps.each_with_index do |resultsMap, index|
       if index != 0
-        if isRelease == true
+        if isRelease == "true"
             generateAndroidFile("results/strings_" + $whiteLabels[index - 1] + ".xml", resultsMap)
             puts "Android #{$whiteLabels[index - 1]} written"
         else

--- a/main.rb
+++ b/main.rb
@@ -216,6 +216,7 @@ spreadsheet.worksheets.each do |worksheet|
         elsif
             generateAndroidFile("results/master_strings_" + $whiteLabels[index - 1] + ".xml", resultsMap)
             puts "Android #{$whiteLabels[index - 1]} written"
+        end
       end
     end
   end

--- a/main.rb
+++ b/main.rb
@@ -161,7 +161,8 @@ def generateAndroidFile(fileName, map)
 end
 
 spreadsheetKey = ARGV[0]
-if spreadsheetKey == nil
+isRelease = ARGV[1]
+if spreadsheetKey || isRelease == nil
   puts "Script called with wrong number of parameters"
   exit 1
 end
@@ -176,14 +177,22 @@ spreadsheet.worksheets.each do |worksheet|
     puts "Checking iOS Export"
 
     resultsMaps = createLocalisationMap(worksheet)
-    generateIOSFile("results/ios.strings", resultsMaps[0])
+    if isRelease = true
+        generateIOSFile("results/ios.strings", resultsMaps[0])
+    elsif
+        generateIOSFile("results/ios.master.strings", resultsMaps[0])
+    end
 
     puts "iOS Yoti written"
 
     resultsMaps.each_with_index do |resultsMap, index|
-      if index != 0
-        generateIOSFile("results/ios_" + $whiteLabels[index - 1] + ".strings", resultsMap)
-        puts "iOS #{$whiteLabels[index - 1]} written"
+    if index != 0
+      if isRelease = true
+          generateIOSFile("results/ios_" + $whiteLabels[index - 1] + ".strings", resultsMap)
+          puts "iOS #{$whiteLabels[index - 1]} written"
+      elsif
+          generateIOSFile("results/ios_master_" + $whiteLabels[index - 1] + ".strings", resultsMap)
+          puts "iOS #{$whiteLabels[index - 1]} written"
       end
     end
   elsif (worksheet.title == "Android Export")
@@ -191,14 +200,22 @@ spreadsheet.worksheets.each do |worksheet|
     puts "Checking Android Export"
 
     resultsMaps = createLocalisationMap(worksheet)
-    generateAndroidFile("results/strings.xml", resultsMaps[0])
+    if isRelease = true
+        generateAndroidFile("results/strings.xml", resultsMaps[0])
+    elsif
+        generateAndroidFile("results/master_strings.xml", resultsMaps[0])
+    end
 
     puts "Android Yoti written"
 
     resultsMaps.each_with_index do |resultsMap, index|
       if index != 0
-        generateAndroidFile("results/strings_" + $whiteLabels[index - 1] + ".xml", resultsMap)
-        puts "Android #{$whiteLabels[index - 1]} written"
+        if isRelease = true
+            generateAndroidFile("results/master_strings_" + $whiteLabels[index - 1] + ".xml", resultsMap)
+            puts "Android #{$whiteLabels[index - 1]} written"
+        elsif
+            generateAndroidFile("results/master_strings_" + $whiteLabels[index - 1] + ".xml", resultsMap)
+            puts "Android #{$whiteLabels[index - 1]} written"
       end
     end
   end

--- a/main.rb
+++ b/main.rb
@@ -179,7 +179,7 @@ spreadsheet.worksheets.each do |worksheet|
     resultsMaps = createLocalisationMap(worksheet)
     if isRelease == true
         generateIOSFile("results/ios.strings", resultsMaps[0])
-    elsif
+    else
         generateIOSFile("results/ios.master.strings", resultsMaps[0])
     end
 
@@ -190,7 +190,7 @@ spreadsheet.worksheets.each do |worksheet|
         if isRelease == true
             generateIOSFile("results/ios_" + $whiteLabels[index - 1] + ".strings", resultsMap)
             puts "iOS #{$whiteLabels[index - 1]} written"
-        elsif
+        else
             generateIOSFile("results/ios_master_" + $whiteLabels[index - 1] + ".strings", resultsMap)
             puts "iOS #{$whiteLabels[index - 1]} written"
         end
@@ -203,7 +203,7 @@ spreadsheet.worksheets.each do |worksheet|
     resultsMaps = createLocalisationMap(worksheet)
     if isRelease == true
         generateAndroidFile("results/strings.xml", resultsMaps[0])
-    elsif
+    else
         generateAndroidFile("results/master_strings.xml", resultsMaps[0])
     end
 
@@ -214,7 +214,7 @@ spreadsheet.worksheets.each do |worksheet|
         if isRelease == true
             generateAndroidFile("results/master_strings_" + $whiteLabels[index - 1] + ".xml", resultsMap)
             puts "Android #{$whiteLabels[index - 1]} written"
-        elsif
+        else
             generateAndroidFile("results/master_strings_" + $whiteLabels[index - 1] + ".xml", resultsMap)
             puts "Android #{$whiteLabels[index - 1]} written"
         end

--- a/main.rb
+++ b/main.rb
@@ -186,13 +186,14 @@ spreadsheet.worksheets.each do |worksheet|
     puts "iOS Yoti written"
 
     resultsMaps.each_with_index do |resultsMap, index|
-    if index != 0
-      if isRelease == true
-          generateIOSFile("results/ios_" + $whiteLabels[index - 1] + ".strings", resultsMap)
-          puts "iOS #{$whiteLabels[index - 1]} written"
-      elsif
-          generateIOSFile("results/ios_master_" + $whiteLabels[index - 1] + ".strings", resultsMap)
-          puts "iOS #{$whiteLabels[index - 1]} written"
+      if index != 0
+        if isRelease == true
+            generateIOSFile("results/ios_" + $whiteLabels[index - 1] + ".strings", resultsMap)
+            puts "iOS #{$whiteLabels[index - 1]} written"
+        elsif
+            generateIOSFile("results/ios_master_" + $whiteLabels[index - 1] + ".strings", resultsMap)
+            puts "iOS #{$whiteLabels[index - 1]} written"
+        end
       end
     end
   elsif (worksheet.title == "Android Export")

--- a/main.rb
+++ b/main.rb
@@ -180,7 +180,7 @@ spreadsheet.worksheets.each do |worksheet|
     if isRelease == "true"
         generateIOSFile("results/ios.strings", resultsMaps[0])
     else
-        generateIOSFile("results/ios.master.strings", resultsMaps[0])
+        generateIOSFile("results/ios_master.strings", resultsMaps[0])
     end
 
     puts "iOS Yoti written"


### PR DESCRIPTION
## Purpose
In this PR, we are updating the copy scripts to support pulling files from the master spreadsheet.

## External References (e.g. Jira / Zeplin / Confluence)
https://lampkicking.atlassian.net/browse/YM-33026

## Approach
Add a new parameter, to be set in concourse, to toggle between the two naming schemes for the release strings and the master strings

## Scope of changes
_Is there any area that might be affected?_

## Checklist
See POC pipeline here - https://concourse.internal.yoti.com/teams/android/pipelines/YM-33026


@lampkicking/android-dev
@lampkicking/ios-dev